### PR TITLE
Rowheight scales after fontsize so can override.

### DIFF
--- a/js/CaTRoX_QWR/Panel_Playlist.js
+++ b/js/CaTRoX_QWR/Panel_Playlist.js
@@ -394,8 +394,6 @@ function PlaylistPanel(x, y) {
         this.x = x;
         this.y = y;
 
-        g_properties.row_h = Math.round(pref.font_size_playlist * 1.667);
-
         playlist_info_h = scaleForDisplay(g_properties.row_h + 4);
         playlist_info_and_gap_h = playlist_info_h + scaleForDisplay(2);
         playlist.on_size(playlist_w, playlist_h - (g_properties.show_playlist_info ? playlist_info_and_gap_h : 0),

--- a/js/georgia-main.js
+++ b/js/georgia-main.js
@@ -2547,6 +2547,7 @@ function fetchNewArtwork(metadb) {
 	if (timings.showDebugTiming) artworkTime = fb.CreateProfiler('fetchNewArtwork');
 	console.log('Fetching new art'); // can remove this soon
 	aa_list = [];
+	aa_filter = [];
 	var disc_art_exists = true;
 
 	if (pref.display_cdart && !isStreaming) { // we must attempt to load CD/vinyl art first so that the shadow is drawn correctly
@@ -2590,7 +2591,8 @@ function fetchNewArtwork(metadb) {
 		for (k = 0; k < tf.glob_paths.length; k++) {
 			aa_list = aa_list.concat(utils.Glob($(tf.glob_paths[k])).toArray());
 		}
-		pattern = /(cd|vinyl)([0-9]*|[a-h])\.png/i;
+		aa_filter = tf.artwork_filter.split('|');
+		pattern = new RegExp("((cd|vinyl)([0-9]*|[a-h])\.png|(" + aa_filter + ")([0-9]*|[a-h])\.(?:jpg|png))", 'i');
 		// remove duplicates and cd/vinyl art
 		aa_list = _.remove(_.uniq(aa_list), function (path) {
 			return !pattern.test(path);

--- a/js/georgia-main.js
+++ b/js/georgia-main.js
@@ -1138,6 +1138,7 @@ function onOptionsMenu(x, y) {
 			} else {
 				pref.font_size_playlist = size;
 			}
+			g_properties.row_h = Math.round(pref.font_size_playlist * 1.667);
 			playlist.on_size(ww, wh);
 			window.Repaint();
 		});

--- a/js/globals.js
+++ b/js/globals.js
@@ -26,6 +26,7 @@ pref.add_properties({
 	locked: ['Lock theme', false], // true: prevent changing theme with right click
 	rotation_amt: ['Art: Degrees to rotate CDart', 3], // # of degrees to rotate per track change.
 	aa_glob: ['Art: Cycle through all images', true], // true: use glob, false: use albumart reader (front only)
+	artwork_filter: ['Art: Filter Artwork by file names (| Separator)', ''], // string: example "discart" if metadata consumer uses that name for cdart and you don't want those as albumart
 	display_cdart: ['Art: Display CD art', true], // true: show CD artwork behind album artwork. This artwork is expected to be named cd.png and have transparent backgrounds (can be found at fanart.tv)
 	art_rotate_delay: ['Art: Seconds to display each art', 30], // seconds per image
 	rotate_cdart: ['Art: Rotate CD art on new track', true], // true: rotate cdArt based on track number. i.e. rotationAmt = %tracknum% * x degrees


### PR DESCRIPTION
- Row scaling after the font size changed is the first one.
- Secondly, my metadata consumes the musicbrainz and names my cdart "discart"; which with the default regex is a huge problem. This way you can add your own stuff if you want, | split. In my case I just entered discart and it picks the right one and removes any jpgs it can't use- and that you wouldn't want to inadvertently end up showing up as album art.

Please let me know if you want me to stage the transport spacing. I can also bundle in menu button visibility if you'd like.