### PR TITLE
Rowheight scales after fontsize so can override.

### DIFF
--- a/js/CaTRoX_QWR/Panel_Playlist.js
+++ b/js/CaTRoX_QWR/Panel_Playlist.js
@@ -394,8 +394,6 @@ function PlaylistPanel(x, y) {
         this.x = x;
         this.y = y;
 
-        g_properties.row_h = Math.round(pref.font_size_playlist * 1.667);
-
         playlist_info_h = scaleForDisplay(g_properties.row_h + 4);
         playlist_info_and_gap_h = playlist_info_h + scaleForDisplay(2);
         playlist.on_size(playlist_w, playlist_h - (g_properties.show_playlist_info ? playlist_info_and_gap_h : 0),

--- a/js/georgia-main.js
+++ b/js/georgia-main.js
@@ -2590,7 +2590,11 @@ function fetchNewArtwork(metadb) {
 		for (k = 0; k < tf.glob_paths.length; k++) {
 			aa_list = aa_list.concat(utils.Glob($(tf.glob_paths[k])).toArray());
 		}
-		pattern = /(cd|vinyl)([0-9]*|[a-h])\.png/i;
+		if( tf.artwork_cdart_filename.trim().length == 0 ) {
+			pattern = /(cd|vinyl)([0-9]*|[a-h])\.png/i;
+		} else {
+			pattern = new RegExp("((cd|vinyl|" + tf.artwork_cdart_filename.trim() + ")([0-9]*|[a-h])\.png|(" + tf.artwork_cdart_filename.trim() + ")([0-9]*|[a-h])\.(?:jpg))", 'i');
+		}
 		// remove duplicates and cd/vinyl art
 		aa_list = _.remove(_.uniq(aa_list), function (path) {
 			return !pattern.test(path);

--- a/js/georgia-main.js
+++ b/js/georgia-main.js
@@ -1138,6 +1138,7 @@ function onOptionsMenu(x, y) {
 			} else {
 				pref.font_size_playlist = size;
 			}
+			g_properties.row_h = Math.round(pref.font_size_playlist * 1.667);
 			playlist.on_size(ww, wh);
 			window.Repaint();
 		});

--- a/js/globals.js
+++ b/js/globals.js
@@ -26,6 +26,7 @@ pref.add_properties({
 	locked: ['Lock theme', false], // true: prevent changing theme with right click
 	rotation_amt: ['Art: Degrees to rotate CDart', 3], // # of degrees to rotate per track change.
 	aa_glob: ['Art: Cycle through all images', true], // true: use glob, false: use albumart reader (front only)
+	artwork_cdart_filename: ['Art: CDart alternate filename', ''], // string: example "discart" if metadata consumer uses that name for cdart and you don't want those as albumart
 	display_cdart: ['Art: Display CD art', true], // true: show CD artwork behind album artwork. This artwork is expected to be named cd.png and have transparent backgrounds (can be found at fanart.tv)
 	art_rotate_delay: ['Art: Seconds to display each art', 30], // seconds per image
 	rotate_cdart: ['Art: Rotate CD art on new track', true], // true: rotate cdArt based on track number. i.e. rotationAmt = %tracknum% * x degrees
@@ -201,7 +202,11 @@ tf.labels = [ // Array of fields to test for publisher. Add, change or re-order 
 pref.vinylside_path = "$replace(%path%,%filename_ext%,)vinyl$if2(" + tf.vinyl_side + ",).png" // vinyl cdart named vinylA.png, vinylB.png, etc.
 pref.vinyl_path = "$replace(%path%,%filename_ext%,)vinyl.png" // vinyl cdart named vinylA.png, vinylB.png, etc.
 pref.cdartdisc_path = "$replace(%path%,%filename_ext%,)cd$ifgreater(%totaldiscs%,1,%discnumber%,).png"; // cdart named cd1.png, cd2.png, etc.
-pref.cdart_path = "$replace(%path%,%filename_ext%,)cd.png"; // cdart named cd.png  (the far more common single disc albums)
+if( tf.artwork_cdart_filename.trim() == "" ) {
+	pref.cdart_path = "$replace(%path%,%filename_ext%,)cd.png"; // cdart named cd.png  (the far more common single disc albums)
+} else {
+	pref.cdart_path = "$replace(%path%,%filename_ext%,)"+tf.artwork_cdart_filename.trim()+".png"; // cdart named custom.png  (in the case your metadata differs)
+}
 pref.cdart_amount = 0.48; // show 48% of the CD image if it will fit on the screen
 
 function migrateCheck(version, storedVersion) {


### PR DESCRIPTION
- Deleted previous PR's because I wanted to clean it up. I am Ravenmyst (OO) just switched my name.
- Row height scales after fontsize. I tested changing the playlist font, then row height in properties 40 and it was great. That was an excellent suggestion.
- Added the ability to change the CDart name and altered regex filtering for it. In my case, my metadata scraper names my CDart "discart" and saves it as either discart.png or discart.jpg, which leads to issues if you don't modify the Regex.