### PR TITLE
Add transport spacing as configurable property

### DIFF
--- a/js/georgia-main.js
+++ b/js/georgia-main.js
@@ -1071,8 +1071,7 @@ function onOptionsMenu(x, y) {
 	transportSizeMenu.appendTo(transportMenu);
 
 	const transportSpacingMenu = new Menu('Transport Button Spacing');
-	transportSpacingMenu.addRadioItems(['0px', '3px', '5px (default)', '8px', '15px', '20px', '+2'], pref.transport_buttons_spacing, [-1,3,5,8,15,20,999], (size) => {
-		if (size === -1) {
+	transportSpacingMenu.addRadioItems(['-2', '3px', '5px (default)', '7px', '10px', '15px', '+2'], pref.transport_buttons_spacing, [-1,3,5,7,10,15,999], (size) => {		if (size === -1) {
 			pref.transport_buttons_spacing -= 2;
 		} else if (size === 999) {
 			pref.transport_buttons_spacing += 2;
@@ -1081,9 +1080,6 @@ function onOptionsMenu(x, y) {
 		}
 		createButtonImages();
 		createButtonObjects(ww, wh);
-		if (pref.show_transport_below) {
-			ResizeArtwork(true);
-		}
 		RepaintWindow();
 	});
 	transportSpacingMenu.appendTo(transportMenu);

--- a/js/georgia-main.js
+++ b/js/georgia-main.js
@@ -1070,6 +1070,24 @@ function onOptionsMenu(x, y) {
 	});
 	transportSizeMenu.appendTo(transportMenu);
 
+	const transportSpacingMenu = new Menu('Transport Button Spacing');
+	transportSpacingMenu.addRadioItems(['0px', '3px', '5px (default)', '8px', '15px', '20px', '+2'], pref.transport_buttons_spacing, [-1,3,5,8,15,20,999], (size) => {
+		if (size === -1) {
+			pref.transport_buttons_spacing -= 2;
+		} else if (size === 999) {
+			pref.transport_buttons_spacing += 2;
+		} else {
+			pref.transport_buttons_spacing = size;
+		}
+		createButtonImages();
+		createButtonObjects(ww, wh);
+		if (pref.show_transport_below) {
+			ResizeArtwork(true);
+		}
+		RepaintWindow();
+	});
+	transportSpacingMenu.appendTo(transportMenu);
+
 	menu.addToggleItem('Show timeline tooltips', pref, 'show_timeline_tooltips');
 	menu.addToggleItem('Show progress bar', pref, 'show_progress_bar', () => {
 		setGeometry();
@@ -2622,7 +2640,7 @@ function createButtonObjects(ww, wh) {
 		const y = pref.show_transport_below ? wh - geo.lower_bar_h - scaleForDisplay(10) - buttonSize : scaleForDisplay(10);
 		const w = buttonSize;
 		const h = w;
-		const p = scaleForDisplay(5); // space between buttons
+		const p = scaleForDisplay(pref.transport_buttons_spacing); // space between buttons
 		const x = (ww - w * count - p * (count - 1)) / 2;
 
 		const calcX = (index) => {

--- a/js/georgia-main.js
+++ b/js/georgia-main.js
@@ -1072,6 +1072,7 @@ function onOptionsMenu(x, y) {
 
 	const transportSpacingMenu = new Menu('Transport Button Spacing');
 	transportSpacingMenu.addRadioItems(['-2', '3px', '5px (default)', '7px', '10px', '15px', '+2'], pref.transport_buttons_spacing, [-1,3,5,7,10,15,999], (size) => {		if (size === -1) {
+		if (size === -1) {	
 			pref.transport_buttons_spacing -= 2;
 		} else if (size === 999) {
 			pref.transport_buttons_spacing += 2;

--- a/js/georgia-main.js
+++ b/js/georgia-main.js
@@ -1071,7 +1071,7 @@ function onOptionsMenu(x, y) {
 	transportSizeMenu.appendTo(transportMenu);
 
 	const transportSpacingMenu = new Menu('Transport Button Spacing');
-	transportSpacingMenu.addRadioItems(['-2', '3px', '5px (default)', '7px', '10px', '15px', '+2'], pref.transport_buttons_spacing, [-1,3,5,7,10,15,999], (size) => {		if (size === -1) {
+	transportSpacingMenu.addRadioItems(['-2', '3px', '5px (default)', '7px', '10px', '15px', '+2'], pref.transport_buttons_spacing, [-1,3,5,7,10,15,999], (size) => {
 		if (size === -1) {	
 			pref.transport_buttons_spacing -= 2;
 		} else if (size === 999) {

--- a/js/settings.js
+++ b/js/settings.js
@@ -46,6 +46,7 @@ pref.add_properties({
 	show_volume_button: ['Transport: Show Volume Button', false], // true: show volume button in transport controls, ignored if transport is not shown
 	show_reload_button: ['Transport: Show Reload Button', false], // true: show a button that reloads the theme when clicked. Useful for debugging only
 	transport_buttons_size: ['Transport: Button size', 32], // size in pixels of the buttons
+	transport_buttons_spacing: ['Transport: Button spacing', 5], // size in pixels of the button spacing
 
 	show_timeline_tooltips: ['Show timeline tooltips', true], // true: show tooltips when hovering over the timeline that show information on plays
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -46,7 +46,7 @@ pref.add_properties({
 	show_volume_button: ['Transport: Show Volume Button', false], // true: show volume button in transport controls, ignored if transport is not shown
 	show_reload_button: ['Transport: Show Reload Button', false], // true: show a button that reloads the theme when clicked. Useful for debugging only
 	transport_buttons_size: ['Transport: Button size', 32], // size in pixels of the buttons
-	transport_buttons_spacing: ['Transport: Button spacing', 5], // size in pixels of the button spacing
+	transport_buttons_spacing: ['Transport: Button spacing', 5], // size in pixels of the spacing between buttons
 
 	show_timeline_tooltips: ['Show timeline tooltips', true], // true: show tooltips when hovering over the timeline that show information on plays
 


### PR DESCRIPTION
After the transport button size property, there is a new one to space the icons.
I tested this from a base install; an existing one, and tried to look through all of the config for base values, and found no problems with this implementation, but I can make whatever changes you want.

Thanks again for this update, spider monkey panel is a significant upgrade performance wise.