### PR TITLE
Assert file path instead of last leaf

### DIFF
--- a/js/georgia-main.js
+++ b/js/georgia-main.js
@@ -1413,7 +1413,7 @@ function on_playback_new_track(metadb) {
 
 	isStreaming = metadb ? !metadb.RawPath.match(/^file\:\/\//) : false;
 	if (!isStreaming) {
-		currentFolder = $('%directoryname%');
+		currentFolder = metadb.RawPath.substring(0, metadb.RawPath.lastIndexOf("\\"));
 	} else {
 		currentFolder = '';
 	}


### PR DESCRIPTION
Hey there, thanks again for the amazing theme 🚀 I was noticing that my artwork wasn't changing with some of my stuff, so I got to digging. Evidently, the previous value only was storing the leaf folder of the directory structure. In my case, that was typically either CD 01, or CD 02 which caused none of the artwork to ever update. This implementation just gets the file path before making any kind of folder assertion.

Please let me know if something isn't right, and I'll fix it. I tested it and it fixed my issue, but I hope it didn't cause others.